### PR TITLE
Fixed header dependency for ODROID-XU, 3.10.92

### DIFF
--- a/src/modules/pmcs/vexpress_sensors_core.c
+++ b/src/modules/pmcs/vexpress_sensors_core.c
@@ -12,6 +12,7 @@
 
 #include <pmc/vexpress_sensors.h>
 #include <linux/ioport.h>
+#include <linux/regmap.h>
 #include <asm/io.h>
 
 #ifdef CONFIG_PMC_ARM64


### PR DESCRIPTION
For linux kernel version 3.10.92, we need to include header of regmap in
order to avoid compile error.
