### PR TITLE
Fixed non-x86 case of fh_install_hook

### DIFF
--- a/src/modules/pmcs/pmctrack_stub.c
+++ b/src/modules/pmcs/pmctrack_stub.c
@@ -554,6 +554,8 @@ int fh_install_hook(struct ftrace_hook *hook)
 				hook->ops.flags = FTRACE_OPS_FL_SAVE_REGS
 				                  | FTRACE_OPS_FL_IPMODIFY;
 			}
+#else
+			;
 #endif
 #if defined CONFIG_X86
 	if(strcmp(hook->name, "intel_thermal_interrupt") == 0) {


### PR DESCRIPTION
`ftrace_set_filter` in `fh_install_hook` will not be called under the current code for unmodified Linux kernels on non-x86 platforms. It will fall into the "else" logic.